### PR TITLE
Update to GEM 2.1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ FROM quay.io/large-scale-gxe-methods/ubuntu:focal-20210325
 RUN apt update &&\
     apt install -y atop curl dstat
 
-RUN curl -LO https://github.com/large-scale-gxe-methods/GEM/releases/download/v2.1.2/GEM_2.1.1_Intel && \
-    mv GEM_2.1.1_Intel GEM && \
+RUN curl -LO https://github.com/large-scale-gxe-methods/GEM/releases/download/v2.1.2/GEM_2.1.2_Intel && \
+    mv GEM_2.1.2_Intel GEM && \
     chmod +x GEM


### PR DESCRIPTION
This time for real. The previous GEM version (2.1.1) has a printout claiming it is 2.1.2, but this is incorrect.